### PR TITLE
[Feature] Optional notification title

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,9 +81,7 @@ To change the verbose notification text, put `set -g @tnotify-verbose-msg 'put y
 *   `#I`: Window index
 *   `#W`: Window name
 
-Similarly to the notification text you can add a notification title using `set -g @tnotify-verbose-title`. This will move the verbose notification text into the notification body.
-
-For the complete list of aliases and variables, you are referred to the `FORMATS` section of the [tmux manual](http://man7.org/linux/man-pages/man1/tmux.1.html).
+For the complete list of aliases and variables, you are referred to the `FORMATS` section of the [tmux manual](http://man7.org/linux/man-pages/man1/tmux.1.html). You can also add a notification title using `set -g @tnotify-verbose-title`. Doing so will move the verbose notification text into the notification body.
 
 ### Change monitor update period
 

--- a/README.md
+++ b/README.md
@@ -81,6 +81,8 @@ To change the verbose notification text, put `set -g @tnotify-verbose-msg 'put y
 *   `#I`: Window index
 *   `#W`: Window name
 
+Similarly to the notification text you can add a notification title using `set -g @tnotify-verbose-title`. This will move the verbose notification text into the notification body.
+
 For the complete list of aliases and variables, you are referred to the `FORMATS` section of the [tmux manual](http://man7.org/linux/man-pages/man1/tmux.1.html).
 
 ### Change monitor update period

--- a/scripts/cancel.sh
+++ b/scripts/cancel.sh
@@ -11,7 +11,6 @@ source "${CURRENT_DIR}/variables.sh"
 
 # Cancel pane monitoring if active
 if [[ -f "$PID_FILE_PATH" ]]; then
-  
   # Retrieve monitor process PID
   PID=$(cat "$PID_FILE_PATH")
   

--- a/scripts/helpers.sh
+++ b/scripts/helpers.sh
@@ -55,20 +55,28 @@ send_telegram_message() {
 }
 
 # Send notification
-# Usage: notify <message> <send_telegram>
+# Usage: notify <message> <title> <send_telegram>
 notify() {
   # Switch notification method based on OS
   if [[ "$OSTYPE" =~ ^darwin ]]; then # If macOS
-    osascript -e 'display notification "'"$1"'" with title "tmux-notify"'
+    if [ -n "$2" ]; then
+        osascript -e 'display notification "'"$1"'" with title "'"$2"'"'
+    else
+        osascript -e 'display notification "'"$1"'" with title "tmux-notify"'
+    fi
   else
     # notify-send does not always work due to changing dbus params
     # see https://superuser.com/questions/1118878/using-notify-send-in-a-tmux-session-shows-error-no-notification#1118896
-    notify-send "$1"
+    if [ -n "$2" ]; then
+        notify-send "$2" "$1"
+    else
+        notify-send "$1"
+    fi
   fi
   
   # Send telegram message if telegram variables are set, and telegram alert all is
-  # enabled or if the $2 argument is set to true
-  if telegram_available && (telegram_all_enabled || [ "$2" == "true" ]); then
+  # enabled or if the $3 argument is set to true
+  if telegram_available && (telegram_all_enabled || [ "$3" == "true" ]); then
     telegram_bot_id="$(get_tmux_option "$tmux_notify_telegram_bot_id" "$tmux_notify_telegram_bot_id_default")"
     telegram_chat_id="$(get_tmux_option "$tmux_notify_telegram_channel_id" "$tmux_notify_telegram_channel_id_default")"
     send_telegram_message $telegram_bot_id $telegram_chat_id "$1"

--- a/scripts/helpers.sh
+++ b/scripts/helpers.sh
@@ -60,17 +60,17 @@ notify() {
   # Switch notification method based on OS
   if [[ "$OSTYPE" =~ ^darwin ]]; then # If macOS
     if [ -n "$2" ]; then
-        osascript -e 'display notification "'"$1"'" with title "'"$2"'"'
+      osascript -e 'display notification "'"$1"'" with title "'"$2"'"'
     else
-        osascript -e 'display notification "'"$1"'" with title "tmux-notify"'
+      osascript -e 'display notification "'"$1"'" with title "tmux-notify"'
     fi
   else
     # notify-send does not always work due to changing dbus params
     # see https://superuser.com/questions/1118878/using-notify-send-in-a-tmux-session-shows-error-no-notification#1118896
     if [ -n "$2" ]; then
-        notify-send "$2" "$1"
+      notify-send "$2" "$1"
     else
-        notify-send "$1"
+      notify-send "$1"
     fi
   fi
   

--- a/scripts/notify.sh
+++ b/scripts/notify.sh
@@ -41,6 +41,8 @@ if [[ ! -f "$PID_FILE_PATH" ]]; then  # If pane not yet monitored
   if verbose_enabled; then  # If @tnotify-verbose is enabled
     verbose_msg_value="$(get_tmux_option "$verbose_msg_option" "$verbose_msg_default")"
     complete_message=$(tmux display-message -p "$verbose_msg_value")
+    verbose_msg_title="$(get_tmux_option "$verbose_title_option" "$verbose_title_default")"
+    complete_title=$(tmux display-message -p "$verbose_msg_title")
   else  # If @tnotify-verbose is disabled
     complete_message="Tmux pane task completed!"
   fi
@@ -69,7 +71,7 @@ if [[ ! -f "$PID_FILE_PATH" ]]; then  # If pane not yet monitored
         tmux select-window -t @"$WINDOW_ID"
         tmux select-pane -t %"$PANE_ID"
       fi
-      notify "$complete_message" $2
+      notify "$complete_message" "$complete_title" $2
       break
     fi
     

--- a/scripts/notify.sh
+++ b/scripts/notify.sh
@@ -30,7 +30,6 @@ trap 'on_cancel' TERM
 
 # Monitor pane if it is not already monitored
 if [[ ! -f "$PID_FILE_PATH" ]]; then  # If pane not yet monitored
-  
   # job started - create pid-file
   echo "$$" > "$PID_FILE_PATH"
   
@@ -58,7 +57,6 @@ if [[ ! -f "$PID_FILE_PATH" ]]; then  # If pane not yet monitored
   
   # Check process status every 10 seconds to see if has is finished
   while true; do
-    
     # capture pane output
     output=$(tmux capture-pane -pt %"$PANE_ID")
     

--- a/scripts/variables.sh
+++ b/scripts/variables.sh
@@ -25,6 +25,8 @@ export verbose_option="@tnotify-verbose"
 export verbose_default="off"
 export verbose_msg_option="@tnotify-verbose-msg"
 export verbose_msg_default="(#S, #I:#P) Tmux pane task completed!"
+export verbose_title_option="@tnotify-verbose-title"
+export verbose_title_default=""
 
 # Monitor checker interval
 export monitor_sleep_duration="@tnotify-sleep-duration"


### PR DESCRIPTION
I couldn't find any information about merging new features, therefore I hope I'm doing this the correct way :)

I personally prefer my notifications to show the program in the summary and the action/information in the notification body.
This PR adds the `@tnotify-verbose-title`, if it is not set the behavior is unchanged to the current one.
However if it is set, the summary will be replaced with the corresponding value and the `@tnotify-verbose-msg` will be shifted to the message body.

I'm open for suggestions, but I think this is a sensible way to users to set a custom body as well as summary 