### PR TITLE
Trigger Bell in the Monitored Window

### DIFF
--- a/scripts/helpers.sh
+++ b/scripts/helpers.sh
@@ -85,5 +85,5 @@ notify() {
   # trigger visual bell
   # your terminal emulator can be setup to set URGENT bit on visual bell
   # for eg, Xresources -> URxvt.urgentOnBell: true
-  tmux split-window "echo -e \"\a\" && exit"
+  tmux split-window -t "\$$SESSION_ID":@"$WINDOW_ID" "echo -e \"\a\" && exit"
 }

--- a/scripts/notify.sh
+++ b/scripts/notify.sh
@@ -69,7 +69,7 @@ if [[ ! -f "$PID_FILE_PATH" ]]; then  # If pane not yet monitored
         tmux select-window -t @"$WINDOW_ID"
         tmux select-pane -t %"$PANE_ID"
       fi
-      SESSION_ID=$SESSION_ID WINDOW_ID=$WINDOW_ID notify "$complete_message" "$complete_title" $2
+      notify "$complete_message" "$complete_title" $2
       break
     fi
     

--- a/scripts/notify.sh
+++ b/scripts/notify.sh
@@ -69,7 +69,7 @@ if [[ ! -f "$PID_FILE_PATH" ]]; then  # If pane not yet monitored
         tmux select-window -t @"$WINDOW_ID"
         tmux select-pane -t %"$PANE_ID"
       fi
-      notify "$complete_message" "$complete_title" $2
+      SESSION_ID=$SESSION_ID WINDOW_ID=$WINDOW_ID notify "$complete_message" "$complete_title" $2
       break
     fi
     


### PR DESCRIPTION
Love this plugin, however I do not use tmux's audible bell sound and rely on the visual in my status line/bar instead. It's nice to have the visual confirmation on my tmux status line/bar for which windows in my current session are done with their task after being notified by the OS. For those that rely on tmux's visual bell and not just the audible sound, I've found this change to be a must.

This small PR will have the bell trigger in the window that is being monitored rather than in the currently active window.