### PR TITLE
feat: add the `@tnotify-prompt-regex` option

### DIFF
--- a/scripts/notify.sh
+++ b/scripts/notify.sh
@@ -46,14 +46,17 @@ if [[ ! -f "$PID_FILE_PATH" ]]; then  # If pane not yet monitored
     complete_message="Tmux pane task completed!"
   fi
   
-  # Create bash suffix list
-  # NOTE: Looks complicated but uses shell parameter expansion
-  # see https://www.gnu.org/savannah-checkouts/gnu/bash/manual/bash.html#Shell-Parameter-Expansion
-  prompt_suffixes="$(get_tmux_option "$prompt_suffixes" "$prompt_suffixes_default")"
-  prompt_suffixes=${prompt_suffixes// /} # Remove whitespace
-  prompt_suffixes=${prompt_suffixes//,/|} # Replace comma with or operator
-  prompt_suffixes=$(escape_glob_chars "$prompt_suffixes")
-  prompt_suffixes="\(${prompt_suffixes}\)$"
+  prompt_regex_value="$(get_tmux_option "$prompt_regex" "$prompt_regex_default")"
+  if [[ -z "$prompt_regex_value" ]]; then
+    # Create bash suffix list
+    # NOTE: Looks complicated but uses shell parameter expansion
+    # see https://www.gnu.org/savannah-checkouts/gnu/bash/manual/bash.html#Shell-Parameter-Expansion
+    prompt_regex_value="$(get_tmux_option "$prompt_suffixes" "$prompt_suffixes_default")"
+    prompt_regex_value=${prompt_regex_value// /} # Remove whitespace
+    prompt_regex_value=${prompt_regex_value//,/|} # Replace comma with or operator
+    prompt_regex_value=$(escape_glob_chars "$prompt_regex_value")
+    prompt_regex_value="\(${prompt_regex_value}\)$"
+  fi
   
   # Check process status every 10 seconds to see if has is finished
   while true; do
@@ -62,7 +65,7 @@ if [[ ! -f "$PID_FILE_PATH" ]]; then  # If pane not yet monitored
     
     # run tests to determine if work is done
     # if so, break and notify
-    if echo "$output" | tail -n2 | grep -e $prompt_suffixes &> /dev/null; then
+    if echo "$output" | tail -n2 | grep -e $prompt_regex_value &> /dev/null; then
       # tmux display-message "$@"
       if [[ "$1" == "true" ]]; then
         tmux switch -t \$"$SESSION_ID"

--- a/scripts/variables.sh
+++ b/scripts/variables.sh
@@ -17,6 +17,8 @@ export PID_FILE_PATH="${PID_DIR}/${PANE_ID}.pid"
 ## Tnotify tmux options
 export prompt_suffixes="@tnotify-prompt-suffixes"
 export prompt_suffixes_default="$,#,%"
+export prompt_regex="@tnotify-prompt-regex"
+export prompt_regex_default=""
 export custom_notify_command="@tnotify-custom-cmd"
 export custom_notify_command_default="bash ~/Desktop/test.bash"
 


### PR DESCRIPTION
Closes #63.

Example config:

```tmux
set-option -g @tnotify-prompt-regex '^: $'
```